### PR TITLE
twister: Add support for Cpputest

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -459,15 +459,17 @@ harness: <string>
     - pytest
     - gtest
     - robot
+    - cpputest
 
-    Harnesses ``ztest``, ``gtest`` and ``console`` are based on parsing of the
-    output and matching certain phrases. ``ztest`` and ``gtest`` harnesses look
-    for pass/fail/etc. frames defined in those frameworks. Use ``gtest``
-    harness if you've already got tests written in the gTest framework and do
-    not wish to update them to zTest. The ``console`` harness tells Twister to
-    parse a test's text output for a regex defined in the test's YAML file.
-    The ``robot`` harness is used to execute Robot Framework test suites
-    in the Renode simulation framework.
+    Harnesses ``ztest``, ``gtest``, ``cpputest`` and ``console`` are based on parsing of the
+    output and matching certain phrases. ``ztest``, ``gtest`` and ``cpputest`` harnesses look
+    for pass/fail/etc. frames defined in those frameworks. Use ``gtest`` or ``cpputest``
+    harness if you've already got tests written with either of these framework and do
+    not wish to update them to zTest. If using ``cpputest`` be sure to pass the
+    verbose argument ``-v`` to `CommandLineTestRunner::RunAllTests`.
+    The ``console`` harness tells Twister to parse a test's text output
+    for a regex defined in the test's YAML file. The ``robot`` harness is used
+    to execute Robot Framework test suites in the Renode simulation framework.
 
     Some widely used harnesses that are not supported yet:
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -768,6 +768,82 @@ class Test(Harness):
                 tc.reason = "Test failure"
 
 
+class Cpputest(Harness):
+    TEST_START_PATTERN = r".*(?<!Failure in )TEST\((?P<suite_name>[^,]+), (?P<test_name>[^\)]+)\)"
+    TEST_FAIL_PATTERN = r".*Failure in TEST\((?P<suite_name>[^,]+), (?P<test_name>[^\)]+)\).*"
+    FINISHED_PATTERN = r".*(OK|Errors) \(\d+ tests, \d+ ran, \d+ checks, \d+ ignored, \d+ filtered out, \d+ ms\)"
+
+    def __init__(self):
+        super().__init__()
+        self.tc = None
+        self.has_failures = False
+
+    def handle(self, line):
+        if self.state:
+            return
+
+        # Check if a new test starts
+        test_start_match = re.search(self.TEST_START_PATTERN, line)
+        if test_start_match:
+            # If a new test starts and there is an unfinished test, mark it as passed
+            if self.tc is not None:
+                self.tc.status = "passed"
+                self.tc.output = self.testcase_output
+                self.testcase_output = ""
+                self.tc = None
+
+            suite_name = test_start_match.group("suite_name")
+            test_name = test_start_match.group("test_name")
+            if suite_name not in self.detected_suite_names:
+                self.detected_suite_names.append(suite_name)
+
+            name = "{}.{}.{}".format(self.id, suite_name, test_name)
+
+            tc = self.instance.get_case_by_name(name)
+            assert tc is None, "CppUTest error, {} running twice".format(name)
+
+            tc = self.instance.get_case_or_create(name)
+            self.tc = tc
+            self.tc.status = "started"
+            self.testcase_output += line + "\n"
+            self._match = True
+
+        # Check if a test failure occurred
+        test_fail_match = re.search(self.TEST_FAIL_PATTERN, line)
+        if test_fail_match:
+            suite_name = test_fail_match.group("suite_name")
+            test_name = test_fail_match.group("test_name")
+            name = "{}.{}.{}".format(self.id, suite_name, test_name)
+
+            tc = self.instance.get_case_by_name(name)
+            if tc is not None:
+                tc.status = "failed"
+                self.has_failures = True
+                tc.output = self.testcase_output
+                self.testcase_output = ""
+                self.tc = None
+            return
+
+        # Check if the test run finished
+        finished_match = re.search(self.FINISHED_PATTERN, line)
+        if finished_match:
+            # No need to check result if previously there was a failure
+            # or no tests were run
+            if self.has_failures or self.tc is None:
+                return
+
+            tc = self.instance.get_case_or_create(self.tc.name)
+
+            finish_result = finished_match.group(1)
+            if finish_result == "OK":
+                self.state = "passed"
+                tc.status = "passed"
+            else:
+                self.state = "failed"
+                tc.status = "failed"
+            return
+
+
 class Ztest(Test):
     pass
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -193,7 +193,7 @@ class TestInstance:
     def testsuite_runnable(testsuite, fixtures):
         can_run = False
         # console harness allows us to run the test and capture data.
-        if testsuite.harness in [ 'console', 'ztest', 'pytest', 'test', 'gtest', 'robot']:
+        if testsuite.harness in [ 'console', 'ztest', 'pytest', 'test', 'gtest', 'robot','cpputest']:
             can_run = True
             # if we have a fixture that is also being supplied on the
             # command-line, then we need to run the test, not just build it.


### PR DESCRIPTION
Similar to gTest, CppuTest is a CPP framework for unit tests. This commit adds support to detect Cpputest console output when verbose mode is enabled (-v).